### PR TITLE
Fix property typo and move description

### DIFF
--- a/Common/Interfaces/IGame.cs
+++ b/Common/Interfaces/IGame.cs
@@ -9,7 +9,7 @@
 
         IRules Rules { get; set; }
 
-        int NumerberOfTurns { get; set; }
+        int NumberOfTurns { get; set; }
 
         int GetGameWinner(int playerOneScore, int playerTwoScore, int numberOfPlayedTurns);
 

--- a/Common/Models/Game.cs
+++ b/Common/Models/Game.cs
@@ -5,7 +5,7 @@ namespace RockPaperScissors.Models
     public class Game : IGame
     {
         #region properties
-        public int NumerberOfTurns { get; set; }
+        public int NumberOfTurns { get; set; }
         public IPlayer PlayerOne { get; set; }
         public IPlayer PlayerTwo { get; set; }
         public IRules Rules { get; set; }
@@ -20,7 +20,7 @@ namespace RockPaperScissors.Models
         */
         public int GetGameWinner(int playerOneScore, int playerTwoScore, int numberOfPlayedTurns)
         {
-            if (numberOfPlayedTurns == NumerberOfTurns)
+            if (numberOfPlayedTurns == NumberOfTurns)
             {
                 if (playerTwoScore == playerOneScore)
                 {
@@ -32,17 +32,17 @@ namespace RockPaperScissors.Models
                 }
                 return 1;
             }
-            else if(playerOneScore == playerTwoScore && numberOfPlayedTurns< NumerberOfTurns)
+            else if (playerOneScore == playerTwoScore && numberOfPlayedTurns < NumberOfTurns)
             {
                 return -1;
             }
             else
             {
-                if (playerOneScore > NumerberOfTurns / 2.0)
+                if (playerOneScore > NumberOfTurns / 2.0)
                 {
                     return 1;
                 }
-                else if (playerTwoScore > NumerberOfTurns / 2.0)
+                else if (playerTwoScore > NumberOfTurns / 2.0)
                 {
                     return 2;
                 }

--- a/Common/RulesImplementation/RockPaperScissorsRules.cs
+++ b/Common/RulesImplementation/RockPaperScissorsRules.cs
@@ -21,7 +21,7 @@ namespace RockPaperScissors.Common.Rules
                 {
                 new MoveModel { Description = "Rock", RuleValue = 1 },
                 new MoveModel { Description = "Paper", RuleValue = 2 },
-                new MoveModel { Description = "Scissor", RuleValue = 3 }
+                new MoveModel { Description = "Scissors", RuleValue = 3 }
                 };
             }
         }

--- a/MainModule/ViewModels/GameViewModel.cs
+++ b/MainModule/ViewModels/GameViewModel.cs
@@ -33,7 +33,7 @@ namespace MainModule.ViewModels
         private Visibility _playerTwoHumanChoiceVisibility;
         private int _playerOneScore;
         private int _playerTwoScore;
-        private string _numerberOfTurns;
+        private string _numberOfTurns;
         private CancellationTokenSource _tokenSource;
         private CancellationToken _cancellationToken;
         #endregion
@@ -119,10 +119,10 @@ namespace MainModule.ViewModels
             set { SetProperty(ref _moves, value); }
         }
 
-        public string NumerberOfTurns
+        public string NumberOfTurns
         {
-            get { return _numerberOfTurns; }
-            set { SetProperty(ref _numerberOfTurns, value); }
+            get { return _numberOfTurns; }
+            set { SetProperty(ref _numberOfTurns, value); }
         }
 
         #endregion
@@ -226,7 +226,7 @@ namespace MainModule.ViewModels
             PlayerOne = Game.PlayerOne;
             PlayerTwo = Game.PlayerTwo;
             Moves = new ObservableCollection<MoveModel>(Game.Rules.MoveList);
-            NumerberOfTurns = Game.NumerberOfTurns.ToString();
+            NumberOfTurns = Game.NumberOfTurns.ToString();
             _tokenSource = new CancellationTokenSource();
 
             _cancellationToken = _tokenSource.Token;

--- a/MainModule/ViewModels/NewGameViewModel.cs
+++ b/MainModule/ViewModels/NewGameViewModel.cs
@@ -118,7 +118,7 @@ namespace MainModule.ViewModels
             //TODO: Bind this to a property of the options to make the number of turns selectable.
             //PS: changing this value manualy already works
 
-            _game.NumerberOfTurns = 3;
+            _game.NumberOfTurns = 3;
             _game.PlayerOne = playerOne;
             _game.PlayerTwo = playerTwo;
             _game.Rules = new RockPaperScissorsRules();

--- a/MainModule/Views/GameView.xaml
+++ b/MainModule/Views/GameView.xaml
@@ -22,7 +22,7 @@
         </Grid.RowDefinitions>
         <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="3" FontFamily="Segoe UI" FontSize="20" VerticalAlignment="Stretch" Margin="20" HorizontalAlignment="Center">
           <Run FontSize="20" Text="{x:Static resources:Resource.BestOf}"/>
-          <Run FontSize="20" Text="{Binding Path=NumerberOfTurns, Mode=TwoWay}"/>
+          <Run FontSize="20" Text="{Binding Path=NumberOfTurns, Mode=TwoWay}"/>
           <Run FontSize="20" Text="{x:Static resources:Resource.CurrentTurn}"/>
           <Run FontSize="20"  Text="{Binding CurrentTurn, Mode=TwoWay}" />
         </TextBlock>

--- a/UnitTests/GameTests.cs
+++ b/UnitTests/GameTests.cs
@@ -29,7 +29,7 @@ namespace UnitTests
             //ARRANGE
             IGame game = new Game
             {
-                NumerberOfTurns = numberOfTurns
+                NumberOfTurns = numberOfTurns
             };
 
             //ACT


### PR DESCRIPTION
## Summary
- rename `NumerberOfTurns` property to `NumberOfTurns`
- update usages in view models, views and tests
- correct move name to `Scissors`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851784debfc832482730d4bf6c04ef5